### PR TITLE
added CPUID emulation support for the MONITOR/MWAIT leaf

### DIFF
--- a/Lib/emulator.c
+++ b/Lib/emulator.c
@@ -662,6 +662,13 @@ EmulateCPUID(CORNELIUS_VM *Vm, UINT32 VcpuNum, WHV_RUN_VP_EXIT_CONTEXT *ExitCont
         break;
     }
 
+    case 5: // MONITOR/MWAIT Leaf
+      SetRegister64(Vm, VcpuNum, WHvX64RegisterRax, ExitContext->CpuidAccess.DefaultResultRax);
+      SetRegister64(Vm, VcpuNum, WHvX64RegisterRcx, ExitContext->CpuidAccess.DefaultResultRcx);
+      SetRegister64(Vm, VcpuNum, WHvX64RegisterRdx, ExitContext->CpuidAccess.DefaultResultRdx);
+      SetRegister64(Vm, VcpuNum, WHvX64RegisterRbx, ExitContext->CpuidAccess.DefaultResultRbx);
+      break;
+
     case 6: // Thermal and Power Management Leaf
         SetRegister64(Vm, VcpuNum, WHvX64RegisterRax, ExitContext->CpuidAccess.DefaultResultRax);
         SetRegister64(Vm, VcpuNum, WHvX64RegisterRcx, ExitContext->CpuidAccess.DefaultResultRcx);


### PR DESCRIPTION
With this patch, Cornelius appears to run and exit successfully:
```
.\Test.exe pseamldr.so.consts pseamldr.so libtdx.so
[+] Creating the Cornelius VM
[+] Executing PSEAMLDR.INSTALL on VCPU0
[+] Executing PSEAMLDR.INSTALL on VCPU1
[+] Executing PSEAMLDR.INSTALL on VCPU2
[+] Executing PSEAMLDR.INSTALL on VCPU3
[+] Executing TDH.SYS.INIT
[+] Executing TDH.SYS.LP.INIT on VCPU0
[+] Executing TDH.SYS.LP.INIT on VCPU1
[+] Executing TDH.SYS.LP.INIT on VCPU2
[+] Executing TDH.SYS.LP.INIT on VCPU3
[+] Executing TDH.SYS.CONFIG
[+] Executing TDH.SYS.KEY.CONFIG
[+] Executing TDH.SYS.TDMR.INIT
[+] Executing TDH.MNG.CREATE
[+] Executing TDH.MNG.KEY.CONFIG
[+] Executing TDH.MNG.ADDCX
[+] Executing TDH.MNG.INIT
[+] Executing TDH.VP.CREATE on TDVCPU0
[+] Executing TDH.VP.ADDCX on TDVCPU0
[+] Executing TDH.VP.INIT on TDVCPU0
[+] Executing TDH.VP.CREATE on TDVCPU1
[+] Executing TDH.VP.ADDCX on TDVCPU1
[+] Executing TDH.VP.INIT on TDVCPU1
[+] Executing TDH.MEM.SEPT.ADD with entry level 3
[+] Executing TDH.MEM.SEPT.ADD with entry level 2
[+] Executing TDH.MEM.SEPT.ADD with entry level 1
[+] Executing TDH.MR.FINALIZE
[+] Executing TDH.MEM.PAGE.AUG
[+] Executing TDH.VP.ENTER
[+] Taking snapshot
[+] TD executing TDG.MEM.PAGE.ACCEPT
[+] Doing VMEXIT from TD guest
[+] TD executing PSEAMLDR.INFO
[+] Restoring snapshot
[+] Doing VMEXIT from TD guest
[+] Finished successfully
```

This patch is intended to fix https://github.com/microsoft/Cornelius/issues/7.